### PR TITLE
Added a routine which installed the required vargant plugins.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,6 +16,21 @@ def which(cmd)
     end
     return nil
 end
+
+# Check if the vagrant plugins are installed
+# http://stackoverflow.com/questions/19492738/demand-a-vagrant-plugin-within-the-vagrantfile/19507570#19507570
+required_plugins = %w(vagrant-vbguest)
+
+plugins_to_install = required_plugins.select { |plugin| not Vagrant.has_plugin? plugin }
+if not plugins_to_install.empty?
+  puts "Installing plugins: #{plugins_to_install.join(' ')}"
+  if system "vagrant plugin install #{plugins_to_install.join(' ')}"
+    exec "vagrant #{ARGV.join(' ')}"
+  else
+    abort "Installation of one or more plugins has failed. Aborting."
+  end
+end
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     config.vm.provider :virtualbox do |v|


### PR DESCRIPTION
The vagrant-vbguest plugin was missing. So i added a routine which checks if vagrant-vbguest is installed. If not it will be installed. It is also possible to a add further vargant plugins. 
For example
+required_plugins = %w(vagrant-vbguest) to 
+required_plugins = %w(vagrant-sharevagrant-vbguest).